### PR TITLE
Fix AnchorPos::Below with zero label spacing

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -451,7 +451,7 @@ impl TreeFormatting {
         format!(
             "{}{}",
             self.chars.just_space(),
-            if self.anchor == AnchorPosition::Below {
+            if self.anchor == AnchorPosition::Below && self.chars.label_space_count > 0 {
                 self.chars.horizontal_space.to_string()
             } else {
                 String::new()
@@ -464,7 +464,7 @@ impl TreeFormatting {
         format!(
             "{}{}",
             self.chars.bar_and_space(),
-            if self.anchor == AnchorPosition::Below {
+            if self.anchor == AnchorPosition::Below && self.chars.label_space_count > 0 {
                 self.chars.horizontal_space.to_string()
             } else {
                 String::new()

--- a/tests/test_top_down_trees.rs
+++ b/tests/test_top_down_trees.rs
@@ -90,6 +90,36 @@ fn test_box_char_below_tree() {
 }
 
 #[test]
+fn test_box_char_below_tree_no_label_spacing() {
+    let tree = make_tree();
+    let mut format = FormatCharacters::box_chars();
+    format.label_space_count = 0;
+
+    let result =
+        tree.to_string_with_format(&TreeFormatting::dir_tree(format));
+    assert!(result.is_ok());
+    let result = result.unwrap();
+    println!("{}", result);
+    assert_eq!(
+        result,
+        r#"root
+├──Uncle
+├──Parent
+│  ├──Child 1
+│  │  └──Grand Child 1
+│  └──Child 2
+│     └──Grand Child 2
+│        └──Great Grand Child 2
+│           └──Great Great Grand Child 2
+└──Aunt
+   └──Child 3
+"#
+        .to_string()
+    );
+}
+
+
+#[test]
 fn test_ascii_side_tree() {
     let tree = make_tree();
 


### PR DESCRIPTION
First: Thanks for this awesome tiny library that just nice to use!.

Tuning the output I found a minor bug - if you set the label spacing to 0, 
AnchorPos::Below starts from the second character of the label
instead of the first one.

This patches that behaviour

Before this PR:
```
├──Uncle
├──Parent
│   ├──Child 1
│   │   └──Grand Child 1
│   └──Child 2
│       └──Grand Child 2
│           └──Great Grand Child 2
│               └──Great Great Grand Child 2
└──Aunt
    └──Child 3
```

After this PR
```
├──Uncle
├──Parent
│  ├──Child 1
│  │  └──Grand Child 1
│  └──Child 2
│     └──Grand Child 2
│        └──Great Grand Child 2
│           └──Great Great Grand Child 2
└──Aunt
   └──Child 3

```